### PR TITLE
Improve usability of Time module

### DIFF
--- a/time-ballerina/tests/time_test.bal
+++ b/time-ballerina/tests/time_test.bal
@@ -93,7 +93,7 @@ function testParseTimeWithTimePartOnly() {
 
 @test:Config {}
 function testParseRFC1123Time() {
-    var timeRet = parse("Wed, 28 Mar 2018 11:56:23 +0530", TIME_FORMAT_RFC_1123);
+    var timeRet = parse("Wed, 28 Mar 2018 11:56:23 +0530", RFC_1123_DATE_TIME);
     if (timeRet is Time) {
         test:assertEquals(timeRet.time, 1522218383000);
         test:assertEquals(timeRet.zone.id, "+05:30");
@@ -152,7 +152,7 @@ function testFormatTimeToRFC1123() {
     string retValue = "";
     TimeZone zoneValue = {id:"America/Panama"};
     Time time = { time: 1498488382444, zone: zoneValue };
-    var ret = format(time, TIME_FORMAT_RFC_1123);
+    var ret = format(time, RFC_1123_DATE_TIME);
     if (ret is string ) {
         retValue = ret;
         test:assertEquals(ret, "Mon, 26 Jun 2017 09:46:22 -0500");
@@ -172,7 +172,7 @@ function testGetFunctions() {
     int minute = getMinute(time);
     int second = getSecond(time);
     int milliSecond = getMilliSecond(time);
-    string weekday = getWeekday(time);
+    DayOfWeek weekday = getWeekday(time);
     test:assertEquals(year, 2016);
     test:assertEquals(month, 3);
     test:assertEquals(day, 1);
@@ -210,7 +210,16 @@ function testGetTimeFunction() {
 function testAddDuration() {
     var timeRet = parse("2017-06-26T09:46:22.444-0500", "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
     if (timeRet is Time) {
-        Time timeAdded = addDuration(timeRet, 1, 1, 1, 1, 1, 1, 1);
+        Duration d = {
+                years: 1,
+                months: 1,
+                days: 1,
+                hours: 1,
+                minutes: 1,
+                seconds: 1,
+                milliSeconds: 1
+            };
+        Time timeAdded = addDuration(timeRet, d);
         var retStr = format(timeAdded, "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
         if (retStr is string) {
             test:assertEquals(retStr, "2018-07-27T10:47:23.445-0500");
@@ -226,7 +235,16 @@ function testAddDuration() {
 function testSubtractDuration() {
     var timeRet = parse("2016-03-01T09:46:22.444-0500", "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
     if (timeRet is Time) {
-        Time timeSubs = subtractDuration(timeRet, 1, 1, 1, 1, 1, 1, 1);
+        Duration d = {
+                years: 1,
+                months: 1,
+                days: 1,
+                hours: 1,
+                minutes: 1,
+                seconds: 1,
+                milliSeconds: 1
+            };
+        Time timeSubs = subtractDuration(timeRet, d);
         var retStr = format(timeSubs, "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
         if (retStr is string) {
             test:assertEquals(retStr, "2015-01-31T08:45:21.443-0500");
@@ -437,6 +455,28 @@ function testParseTimeWithDifferentFormats() {
     test:assertEquals(dateZoneStr, "2015-02-15+0800");
     test:assertEquals(timeZoneStr, "08-23-59-544:+0700");
     test:assertEquals(datetimeStr, "2014-05-29-23:44:59.544");
+}
+
+@test:Config {}
+function testGetDifference() {
+    Time|Error timeone = createTime(2020, 1,1);
+    Time|Error timetwo = createTime(2021, 1,1);
+    if (timeone is Time && timetwo is Time) {
+        Duration|Error delta = getDifference(timeone, timetwo);
+        if (delta is Duration) {
+            test:assertEquals(delta.years, 1);
+        } else {
+            test:assertFail("Error obtaining difference. " + delta.message());
+        }
+    } else {
+        test:assertFail("Error creating time to obtain difference!");
+    }
+}
+
+@test:Config {}
+function testGetTimezones() {
+    string[] zones = getTimezones(-36000000);
+    test:assertEquals(zones.indexOf("Pacific/Honolulu"), 4);
 }
 
  function systemNanoTime() returns int = @java:Method {

--- a/time-ballerina/time_enums.bal
+++ b/time-ballerina/time_enums.bal
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Date-Time formatters used in time:format() and time:parse()
+#
+# + BASIC_ISO_DATE - Sample format - yyyyMMddZZZ (eg: 20210228+0530)
+# + ISO_DATE - Sample format - yyyy-MM-ddXXX (eg: 2021-02-28+05:30)
+# + ISO_TIME - Sample format - HH:mm:ss.SSZZZZZ (eg: 23:10:15.02+05:30)
+# + ISO_DATE_TIME - Sample format - yyyy-MM-dd'T'HH-mm-ss.SSXXX'['VV']' (eg: 2021-02-28T23:10:15.02+05:30[Asia/Colombo])
+# + ISO_LOCAL_DATE_TIME - Sample format - yyyy-MM-dd'T'HH-mm-ss.SS (eg: 2021-02-28T23:10:15.02)
+# + ISO_OFFSET_DATE_TIME - Sample format - yyyy-MM-dd'T'HH-mm-ss.SSXXX (eg: 2021-02-28T23:10:15.02+05:30)
+# + ISO_ZONED_DATE_TIME - Similar to ISO_DATE_TIME but offset is compulsory
+# + RFC_1123_DATE_TIME - Sample format - E, dd LLL yyyy HH:mm:ss ZZZ (eg: Sun, 28 Feb 2021 23:10:15 +0530)
+public enum DateTimeFormat {
+	BASIC_ISO_DATE,
+	ISO_DATE,
+	ISO_TIME,
+	ISO_DATE_TIME,
+	ISO_LOCAL_DATE_TIME,
+	ISO_OFFSET_DATE_TIME,
+	ISO_ZONED_DATE_TIME,
+	RFC_1123_DATE_TIME
+}
+
+# Values returned by time:getWeekday()
+public enum DayOfWeek {
+    MONDAY,
+    TUESDAY,
+    WEDNESDAY,
+    THURSDAY,
+    FRIDAY,
+    SATURDAY,
+    SUNDAY
+}

--- a/time-ballerina/timelib.bal
+++ b/time-ballerina/timelib.bal
@@ -16,12 +16,6 @@
 
 import ballerina/java;
 
-# Specifies the time format defined by the RFC-1123.
-public const TIME_FORMAT_RFC_1123 = "RFC_1123";
-
-# The time format defined by the RFC-1123.
-public type TimeFormat TIME_FORMAT_RFC_1123;
-
 # Represents the time-zone information associated with a particular time.
 #
 # + id - Zone short ID or offset string
@@ -38,6 +32,25 @@ public type TimeZone record {|
 public type Time record {|
     int time;
     TimeZone zone;
+|};
+
+# Represents a chunk of time.
+#
+# + years - Number of years
+# + months - Number of months
+# + days - Number of days
+# + hours - Number of hours
+# + minutes - Number of minutes
+# + seconds - Number of seconds
+# + milliSeconds - Number of milliseconds
+public type Duration record {|
+    int years = 0;
+    int months = 0;
+    int days = 0;
+    int hours = 0;
+    int minutes = 0;
+    int seconds = 0;
+    int milliSeconds = 0;
 |};
 
 # Returns the ISO 8601 string representation of the given time.
@@ -64,7 +77,7 @@ public isolated function toString(Time time) returns string = @java:Method {
 # + time - The Time record to be formatted
 # + timeFormat - The format, which is used to format the time represented by this object
 # + return - The formatted string of the given time or else a `time:Error` if failed to format the time
-public isolated function format(Time time, string timeFormat) returns string|Error = @java:Method {
+public isolated function format(Time time, DateTimeFormat|string timeFormat) returns string|Error = @java:Method {
     name: "format",
     'class: "org.ballerinalang.stdlib.time.nativeimpl.ExternMethods"
 } external;
@@ -120,7 +133,7 @@ public isolated function getDay(Time time) returns int = @java:Method {
 #
 # + time - The Time record to get the weekday representation
 # + return - The weekday representation from SUNDAY to SATURDAY
-public isolated function getWeekday(Time time) returns string = @java:Method {
+public isolated function getWeekday(Time time) returns DayOfWeek = @java:Method {
     name: "getWeekday",
     'class: "org.ballerinalang.stdlib.time.nativeimpl.ExternMethods"
 } external;
@@ -219,22 +232,16 @@ public isolated function getTime(Time time) returns [int, int, int, int] = @java
 #  string timeText = "2020-06-26T09:46:22.444-0500";
 #  string timeFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 #  time:Time|error originalTime = time:parse(timeText, timeFormat);
+#  Duration delta = {years: 1, months: 2};
 #  if (originalTime is time:Time) {
-#      time:Time newTime = time:addDuration(originalTime, 1, 1, 1, 1, 1, 1, 1);
+#      time:Time newTime = time:addDuration(originalTime, delta);
 #  }
 # ```
 #
 # + time - The Time record to add the duration 
-# + years - The year representation
-# + months - The month-of-year to represent, from 1 (January) to 12 (December)
-# + days - The day-of-month to represent, from 1 to 31
-# + hours - The hour-of-day to represent, from 0 to 23
-# + minutes - The minute-of-hour to represent, from 0 to 59
-# + seconds - The second-of-minute to represent, from 0 to 59
-# + milliSeconds - The milli-of-second to represent, from 0 to 999
+# + duration - The duration to be added
 # + return - Time object containing time and zone information after the addition
-public isolated function addDuration(Time time, int years, int months, int days, int hours, int minutes, int seconds,
-                            int milliSeconds) returns Time = @java:Method {
+public isolated function addDuration(Time time, Duration duration) returns Time = @java:Method {
     name: "addDuration",
     'class: "org.ballerinalang.stdlib.time.nativeimpl.ExternMethods"
 } external;
@@ -244,22 +251,16 @@ public isolated function addDuration(Time time, int years, int months, int days,
 #  string timeText = "2020-06-26T09:46:22.444-0500";
 #  string timeFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 #  time:Time|error originalTime = time:parse(timeText, timeFormat);
+#  Duration delta = {years: 1, months: 2};
 #  if (originalTime is time:Time) {
-#      time:Time newTime = time:subtractDuration(originalTime, 1, 1, 1, 1, 1, 1, 1);
+#      time:Time newTime = time:subtractDuration(originalTime, delta);
 #  }
 # ```
 #
 # + time - The Time record to subtract the duration from
-# + years - The year representation
-# + months - The month-of-year to represent, from 1 (January) to 12 (December)
-# + days - The day-of-month to represent, from 1 to 31
-# + hours - The hour-of-day to represent, from 0 to 23
-# + minutes - The minute-of-hour to represent, from 0 to 59
-# + seconds - The second-of-minute to represent, from 0 to 59
-# + milliSeconds - The milli-of-second to represent, from 0 to 999
+# + duration - The duration to be subtracted
 # + return - Time object containing time and zone information after the subtraction
-public isolated function subtractDuration(Time time, int years, int months, int days, int hours, int minutes, int
-                        seconds, int milliSeconds) returns Time = @java:Method {
+public isolated function subtractDuration(Time time, Duration duration) returns Time = @java:Method {
     name: "subtractDuration",
     'class: "org.ballerinalang.stdlib.time.nativeimpl.ExternMethods"
 } external;
@@ -317,8 +318,8 @@ public isolated function nanoTime() returns int = @java:Method {
 # + milliSecond - The milli-of-second to represent, from 0 to 999
 # + zoneId - The zone id of the required time-zone.If empty the system local time-zone will be used
 # + return - Time object containing time and zone information or an `time:Error` if failed to create the time
-public isolated function createTime(int year, int month, int date, int hour, int minute, int second, int milliSecond,
-                           string zoneId) returns Time|Error = @java:Method {
+public isolated function createTime(int year, int month, int date, int hour = 0, int minute = 0,
+                        int second = 0, int milliSecond = 0, string zoneId = "") returns Time|Error = @java:Method {
     name: "createTime",
     'class: "org.ballerinalang.stdlib.time.nativeimpl.ExternMethods"
 } external;
@@ -332,7 +333,30 @@ public isolated function createTime(int year, int month, int date, int hour, int
 # + data - The time text to parse
 # + timeFormat - The format, which is used to parse the given text
 # + return - Time object containing the time and zone information or else  a `time:Error` if failed to parse the given string
-public isolated function parse(string data, string timeFormat) returns Time|Error = @java:Method {
+public isolated function parse(string data, DateTimeFormat|string timeFormat) returns Time|Error = @java:Method {
     name: "parse",
+    'class: "org.ballerinalang.stdlib.time.nativeimpl.ExternMethods"
+} external;
+
+
+# Calculate the difference between two Time values.
+# ```ballerina
+# Duration|error delta = time:getDifference(timeone, timetwo);
+# ```
+#
+# + timeone - Start time
+# + timetwo - End time
+# + return - The Duration of the difference
+public isolated function getDifference(Time timeone, Time timetwo) returns Duration|Error = @java:Method {
+    name: "getDifference",
+    'class: "org.ballerinalang.stdlib.time.nativeimpl.ExternMethods"
+} external;
+
+# Get available timezone IDs.
+#
+# + offset - Timezone offset in milliseconds
+# + return - All the available timezone IDs or the IDs that fall under an offset, if the offset value is specified
+public isolated function getTimezones(int? offset = ()) returns string[] = @java:Method {
+    name: "getTimezones",
     'class: "org.ballerinalang.stdlib.time.nativeimpl.ExternMethods"
 } external;

--- a/time-native/src/main/java/org/ballerinalang/stdlib/time/util/Constants.java
+++ b/time-native/src/main/java/org/ballerinalang/stdlib/time/util/Constants.java
@@ -31,12 +31,21 @@ public class Constants {
 
     public static final String STRUCT_TYPE_TIME = "Time";
     public static final String STRUCT_TYPE_TIMEZONE = "TimeZone";
+    public static final String STRUCT_TYPE_DURATION = "Duration";
 
     public static final String TIME_ERROR = "TimeError";
     public static final String KEY_ZONED_DATETIME = "ZonedDateTime";
     public static final String TIME_FIELD = "time";
     public static final String ZONE_FIELD = "zone";
     public static final String ZONE_ID_FIELD = "id";
+
+    public static final String YEARS = "years";
+    public static final String MONTHS = "months";
+    public static final String DAYS = "days";
+    public static final String HOURS = "hours";
+    public static final String MINUTES = "minutes";
+    public static final String SECONDS = "seconds";
+    public static final String MILLISECONDS = "milliSeconds";
 
     public static final int MULTIPLIER_TO_NANO = 1000000;
 }


### PR DESCRIPTION
Fixing: https://github.com/ballerina-platform/ballerina-standard-library/issues/655

* Added support for commonly used date/time formatters
* Introduced Duration record and used it in the add/subtract APIs
* Have default params in the createTime API
* Made getWeekday return an enum
* Addednew API to calculate difference between two time records
* Added new API to get timezone IDs supported by the underlying native code