### PR TITLE
Add more details to the invalid format pattern error message

### DIFF
--- a/time-ballerina/Package.md
+++ b/time-ballerina/Package.md
@@ -41,7 +41,7 @@ S|fraction-of-second|fraction|978
 A|milli-of-day|number|1234
 n|nano-of-second|number|987654321
 N|nano-of-day|number|1234000000
-V|ime-zone ID|zone-id|America/Los\_Angeles; Z; -08:30
+V|Time-zone ID|zone-id|America/Los\_Angeles; Z; -08:30
 z|time-zone name|zone-name|Pacific Standard Time; PST
 O|localized zone-offset|offset-O|GMT+8; GMT+08:00; UTC-08:00
 X|zone-offset 'Z' for zero|offset-X|Z; -08; -0830; -08:30; -083015; -08:30:15

--- a/time-native/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/ExternMethods.java
+++ b/time-native/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/ExternMethods.java
@@ -94,7 +94,7 @@ public class ExternMethods {
                     return TimeUtils.getFormattedString(timeRecord, pattern);
             }
         } catch (IllegalArgumentException e) {
-            return TimeUtils.getTimeError("Invalid Pattern: " + pattern.getValue());
+            return TimeUtils.getTimeError("Invalid Pattern: " + pattern.getValue() + ", " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
## Purpose
> Current error message in invalid  format is not descriptive enough to get the actual  error.

Sample  Code

```ballerina
import ballerina/time;
import ballerina/io;
public function main() {
    time:Time currentTime = time:currentTime();

    string|time:TimeError format = time:format(currentTime, "V");
    if (format is string) {
        io:println(format);
    } else {
        io:println(format.message());
    }
}
```

The current output of  above code :
`Invalid Pattern: V`

The  output after the fix:
`Invalid Pattern: V, Pattern letter count must be 2: V`

Related issues: Created https://github.com/ballerina-platform/ballerina-standard-library/issues/922 to track the update of API docs.