### PR TITLE
Enable APIs to use email typed date time strings

### DIFF
--- a/time-ballerina/tests/time_test.bal
+++ b/time-ballerina/tests/time_test.bal
@@ -401,8 +401,84 @@ isolated function testCivilToString() {
 isolated function testUtcToEmailString() {
     Utc|Error utc = utcFromString("2007-12-03T10:15:30.00Z");
     if (utc is Utc) {
-        test:assertEquals(utcToEmailString(utc), "Mon, 3 Dec 2007 10:15:30 GMT");
+        test:assertEquals(utcToEmailString(utc, "GMT"), "Mon, 3 Dec 2007 10:15:30 GMT");
     } else {
         test:assertFail(msg = utc.message());
+    }
+}
+
+@test:Config {}
+isolated function testUtcToEmailStringWithZ() {
+    Utc|Error utc = utcFromString("2007-12-03T10:15:30.00Z");
+    if (utc is Utc) {
+        test:assertEquals(utcToEmailString(utc, "Z"), "Mon, 3 Dec 2007 10:15:30 Z");
+    } else {
+        test:assertFail(msg = utc.message());
+    }
+}
+
+@test:Config {}
+isolated function testCivilFromEmailString() {
+    string dateString = "Wed, 10 Mar 2021 19:51:55 -0800 (PST)";
+    ZoneOffset zoneOffset = {hours: -8, minutes: 0};
+    Civil expectedCivil = {
+        year: 2021,
+        month: 3,
+        day: 10,
+        hour: 19,
+        minute: 51,
+        second: 55,
+        timeAbbrev: "America/Los_Angeles",
+        utcOffset: zoneOffset
+    };
+    Civil|Error civil = civilFromEmailString(dateString);
+    if (civil is Civil) {
+        test:assertEquals(civil, expectedCivil);
+    } else {
+        test:assertFail(msg = civil.message());
+    }
+}
+
+@test:Config {}
+isolated function testCivilToEmailString() {
+    string expectedString = "Wed, 10 Mar 2021 19:51:55 -0800 (PST)";
+    ZoneOffset zoneOffset = {hours: 8, minutes: 0};
+    Civil civil = {
+        year: 2021,
+        month: 3,
+        day: 10,
+        hour: 19,
+        minute: 51,
+        second: 55,
+        timeAbbrev: "America/Los_Angeles",
+        utcOffset: zoneOffset
+    };
+    string|Error emailString = civilToEmailString(civil, ZONE_OFFSET_WITH_TIME_ABBREV_COMMENT);
+    if (emailString is string) {
+        test:assertEquals(emailString, expectedString);
+    } else {
+        test:assertFail(msg = emailString.message());
+    }
+}
+
+@test:Config {}
+isolated function testCivilToEmailStringWithZonePreference() {
+    string expectedString = "Wed, 10 Mar 2021 19:51:55 -0820";
+    ZoneOffset zoneOffset = {hours: -8, minutes: -20};
+    Civil civil = {
+        year: 2021,
+        month: 3,
+        day: 10,
+        hour: 19,
+        minute: 51,
+        second: 55,
+        timeAbbrev: "America/Los_Angeles",
+        utcOffset: zoneOffset
+    };
+    string|Error emailString = civilToEmailString(civil, PREFER_ZONE_OFFSET);
+    if (emailString is string) {
+        test:assertEquals(emailString, expectedString);
+    } else {
+        test:assertFail(msg = emailString.message());
     }
 }

--- a/time-ballerina/tests/time_test.bal
+++ b/time-ballerina/tests/time_test.bal
@@ -207,7 +207,8 @@ isolated function testUtcToCivil() {
             hour: 23,
             minute: 20,
             second: 50.52,
-            timeAbbrev: "Z"
+            timeAbbrev: "Z",
+            dayOfWeek: MONDAY
         };
         test:assertEquals(civil, expectedCivil);
     } else {
@@ -324,7 +325,8 @@ isolated function testCivilFromStringWithZone() {
         minute: 20,
         second: 50.52,
         timeAbbrev: "Asia/Colombo",
-        utcOffset: zoneOffset
+        utcOffset: zoneOffset,
+        dayOfWeek: MONDAY
     };
     Civil|Error civil = civilFromString(dateString);
     if (civil is Civil) {
@@ -344,7 +346,8 @@ isolated function testCivilFromStringWithoutZone() {
         hour: 23,
         minute: 20,
         second: 50.52,
-        timeAbbrev: "Z"
+        timeAbbrev: "Z",
+        dayOfWeek: MONDAY
     };
     Civil|Error civil = civilFromString(dateString);
     if (civil is Civil) {
@@ -365,7 +368,8 @@ isolated function testCivilFromStringWithoutSecond() {
         hour: 23,
         minute: 20,
         timeAbbrev: "Asia/Colombo",
-        utcOffset: zoneOffset
+        utcOffset: zoneOffset,
+        dayOfWeek: MONDAY
     };
     Civil|Error civil = civilFromString(dateString);
     if (civil is Civil) {
@@ -429,7 +433,8 @@ isolated function testCivilFromEmailString() {
         minute: 51,
         second: 55,
         timeAbbrev: "America/Los_Angeles",
-        utcOffset: zoneOffset
+        utcOffset: zoneOffset,
+        dayOfWeek: WEDNESDAY
     };
     Civil|Error civil = civilFromEmailString(dateString);
     if (civil is Civil) {

--- a/time-ballerina/tests/time_test.bal
+++ b/time-ballerina/tests/time_test.bal
@@ -396,3 +396,13 @@ isolated function testCivilToString() {
         test:assertFail(msg = civilStr.message());
     }
 }
+
+@test:Config {}
+isolated function testUtcToEmailString() {
+    Utc|Error utc = utcFromString("2007-12-03T10:15:30.00Z");
+    if (utc is Utc) {
+        test:assertEquals(utcToEmailString(utc), "Mon, 3 Dec 2007 10:15:30 GMT");
+    } else {
+        test:assertFail(msg = utc.message());
+    }
+}

--- a/time-ballerina/time_apis.bal
+++ b/time-ballerina/time_apis.bal
@@ -69,7 +69,7 @@ public isolated function utcAddSeconds(Utc utc, Seconds seconds) returns Utc {
     [int, decimal] [secondsFromEpoch, lastSecondFraction] = utc;
     secondsFromEpoch = secondsFromEpoch + <int>seconds.floor();
     lastSecondFraction = lastSecondFraction + (seconds - seconds.floor());
-    if (lastSecondFraction >= 1) {
+    if (lastSecondFraction >= <decimal>1.0) {
         secondsFromEpoch = secondsFromEpoch + <int>lastSecondFraction.floor();
         lastSecondFraction = lastSecondFraction - lastSecondFraction.floor();
     }

--- a/time-ballerina/time_apis.bal
+++ b/time-ballerina/time_apis.bal
@@ -205,6 +205,14 @@ public isolated function civilToString(Civil civil) returns string|Error {
     utcOffset.minutes, utcOffsetSeconds);
 }
 
+public isolated function utcToEmailString(Utc utc, UtcZoneHandling zh = "0") returns string {
+    string passingZh = zh;
+    if zh == "0" {
+        passingZh = "Z";
+    }
+    return externUtcToEmailString(utc, passingZh);
+}
+
 isolated function externUtcNow(int precision) returns Utc = @java:Method {
     name: "externUtcNow",
     'class: "org.ballerinalang.stdlib.time.nativeimpl.ExternMethods"
@@ -264,5 +272,10 @@ isolated function externCivilToString(int year, int month, int day, int hour, in
 
 isolated function externZoneOffsetFromString(string dateTimeString) returns ZoneOffset? = @java:Method {
     name: "externZoneOffsetFromString",
+    'class: "org.ballerinalang.stdlib.time.nativeimpl.ExternMethods"
+} external;
+
+isolated function externUtcToEmailString(Utc utc, string zh) returns string = @java:Method {
+    name: "externUtcToEmailString",
     'class: "org.ballerinalang.stdlib.time.nativeimpl.ExternMethods"
 } external;

--- a/time-ballerina/time_types.bal
+++ b/time-ballerina/time_types.bal
@@ -83,7 +83,7 @@ type TimeOfDayFields record {
 # + month - month as an integer(1 <= month <= 12)  
 # + year - year as an integer  
 # + day - day as an integer(1 <= day <= 31)  
-public type OptionalDateFields record {
+type OptionalDateFields record {
     int year?;
     int month?;
     int day?;
@@ -94,7 +94,7 @@ public type OptionalDateFields record {
 # + hour - hour as an integer(0 <= hour <= 23)  
 # + minute - minute as an integer(0 <= minute <= 59)   
 # + second - second as decimal value with nanoseconds precision
-public type OptionalTimeOfDayFields record {
+type OptionalTimeOfDayFields record {
     int hour?;
     int minute?;
     Seconds second?;

--- a/time-ballerina/time_types.bal
+++ b/time-ballerina/time_types.bal
@@ -99,6 +99,7 @@ type ReadWriteZoneOffset record {|
 
 # Represents the `Z` zone, hours: 0 and minutes: 0.
 public final ZoneOffset Z = {hours: 0};
+
 # Represents the type that can be either zero or one.
 public type ZERO_OR_ONE 0|1;
 
@@ -120,5 +121,11 @@ public type Civil record {
 };
 
 # Defualt zone value represation in different formats.
-public type UtcZoneHandling "0" | "GMT" | "UT" | "Z";
+public type UtcZoneHandling "0"|"GMT"|"UT"|"Z";
 
+# Indicate how to handle both `zoneOffset` and `timeAbbrev`.
+public enum HeaderZoneHandling {
+    PREFER_TIME_ABBREV,
+    PREFER_ZONE_OFFSET,
+    ZONE_OFFSET_WITH_TIME_ABBREV_COMMENT
+}

--- a/time-ballerina/time_types.bal
+++ b/time-ballerina/time_types.bal
@@ -118,3 +118,7 @@ public type Civil record {
     string timeAbbrev?;
     ZERO_OR_ONE which?;
 };
+
+# Defualt zone value represation in different formats.
+public type UtcZoneHandling "0" | "GMT" | "UT" | "Z";
+

--- a/time-ballerina/time_types.bal
+++ b/time-ballerina/time_types.bal
@@ -118,6 +118,7 @@ public type Civil record {
     # standard time and one for daylight savings time
     string timeAbbrev?;
     ZERO_OR_ONE which?;
+    DayOfWeek dayOfWeek?;
 };
 
 # Defualt zone value represation in different formats.

--- a/time-ballerina/time_types.bal
+++ b/time-ballerina/time_types.bal
@@ -51,14 +51,22 @@ public type Date record {
     int day;
 };
 
-# The day of weel according to the US convention.
+# Represents Sunday from integer 0.
 public const int SUNDAY = 0;
+# Monday represents from integer 1.
 public const int MONDAY = 1;
+# Tuesday represents from integer 2.
 public const int TUESDAY = 2;
+# Wednesday represents from integer 3.
 public const int WEDNESDAY = 3;
+# Thursday represents from integer 4.
 public const int THURSDAY = 4;
+# Friday represents from integer 5.
 public const int FRIDAY = 5;
+# Saturday represents from integer 6.
 public const int SATURDAY = 6;
+
+# The day of weel according to the US convention.
 public type DayOfWeek SUNDAY|MONDAY|TUESDAY|WEDNESDAY|THURSDAY|FRIDAY|SATURDAY;
 
 # Time within a day
@@ -89,7 +97,9 @@ type ReadWriteZoneOffset record {|
     decimal seconds?;
 |};
 
+# Represents the `Z` zone, hours: 0 and minutes: 0.
 public final ZoneOffset Z = {hours: 0};
+# Represents the type that can be either zero or one.
 public type ZERO_OR_ONE 0|1;
 
 # Time within some region relative to a

--- a/time-ballerina/time_types.bal
+++ b/time-ballerina/time_types.bal
@@ -39,18 +39,6 @@ public type Seconds decimal;
 # 86401 on day with a positive leap second).
 public type Utc readonly & [int, decimal];
 
-# Date in proleptic Gregorian calendar.
-public type Date record {
-    # year 1 means AD 1
-    # year 0 means 1 BC
-    # year -1 means 2 BC
-    int year;
-    # month 1 is January, as in ISO 8601
-    int month;
-    # day 1 is first day of month
-    int day;
-};
-
 # Represents Sunday from integer 0.
 public const int SUNDAY = 0;
 # Monday represents from integer 1.
@@ -69,12 +57,66 @@ public const int SATURDAY = 6;
 # The day of weel according to the US convention.
 public type DayOfWeek SUNDAY|MONDAY|TUESDAY|WEDNESDAY|THURSDAY|FRIDAY|SATURDAY;
 
-# Time within a day
-# Not always duration from midnight.
-public type TimeOfDay record {
+# Fields of the Date record.
+#
+# + month - month as an integer(1 <= month <= 12)  
+# + year - year as an integer  
+# + day - day as an integer(1 <= day <= 31)  
+type DateFields record {
+    int year;
+    int month;
+    int day;
+};
+
+# Fields of the TimeOfDay record.
+# + hour - hour as an integer(0 <= hour <= 23)  
+# + minute - minute as an integer(0 <= minute <= 59)   
+# + second - second as decimal value with nanoseconds precision
+type TimeOfDayFields record {
     int hour;
     int minute;
     Seconds second?;
+};
+
+# Date in proleptic Gregorian calendar with all the fields beign optional.
+#
+# + month - month as an integer(1 <= month <= 12)  
+# + year - year as an integer  
+# + day - day as an integer(1 <= day <= 31)  
+public type OptionalDateFields record {
+    int year?;
+    int month?;
+    int day?;
+};
+
+# TimeOfDay with all the fields beign optional.
+#
+# + hour - hour as an integer(0 <= hour <= 23)  
+# + minute - minute as an integer(0 <= minute <= 59)   
+# + second - second as decimal value with nanoseconds precision
+public type OptionalTimeOfDayFields record {
+    int hour?;
+    int minute?;
+    Seconds second?;
+};
+
+# Date in proleptic Gregorian calendar.
+#
+# + utcOffset - optional zone offset 
+public type Date record {
+    *DateFields;
+    *OptionalTimeOfDayFields;
+    ZoneOffset utcOffset?;
+};
+
+# Time within a day
+# Not always duration from midnight.
+#
+# + utcOffset - optional zone offset 
+public type TimeOfDay record {
+    *OptionalDateFields;
+    *TimeOfDayFields;
+    ZoneOffset utcOffset?;
 };
 
 # This is closed so it is a subtype of Delta
@@ -105,17 +147,17 @@ public type ZERO_OR_ONE 0|1;
 
 # Time within some region relative to a
 # time scale stipulated by civilian authorities.
+# + utcOffset - optional zone offset 
+# + timeAbbrev - the string representation of the time zone
+# + which - if present, abbreviation for the local time (e.g. EDT, EST) in effect at the time represented by this record;
+# this is quite the same as the name of a time zone one time zone can have two abbreviations: one for
+# standard time and one for daylight savings time
+# + dayOfWeek - day of the week(SUNDAY, MONDAY, TUESDAY, ... SATURDAY)
 public type Civil record {
     // the date time in that region
-    *Date;
-    *TimeOfDay;
+    *DateFields;
+    *TimeOfDayFields;
     ZoneOffset utcOffset?;
-
-    # if present, abbreviation for the local time (e.g. EDT, EST)
-    # in effect at the time represented by this record;
-    # this is quite the same as the name of a time zone
-    # one time zone can have two abbreviations: one for
-    # standard time and one for daylight savings time
     string timeAbbrev?;
     ZERO_OR_ONE which?;
     DayOfWeek dayOfWeek?;

--- a/time-native/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/ExternMethods.java
+++ b/time-native/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/ExternMethods.java
@@ -34,6 +34,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Extern methods used in Ballerina Time library.
@@ -154,6 +155,13 @@ public class ExternMethods {
         } catch (DateTimeException e) {
             return TimeValueHandler.createError(Errors.FormatError, e.getMessage());
         }
+    }
+
+    public static BString externUtcToEmailString(BArray utc, BString zh) {
+
+        Instant time = TimeValueHandler.createInstantFromUtc(utc);
+        return StringUtils.fromString(ZonedDateTime.ofInstant(time,
+        ZoneId.of(zh.getValue())).format(DateTimeFormatter.RFC_1123_DATE_TIME));
     }
 
 }

--- a/time-native/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/ExternMethods.java
+++ b/time-native/src/main/java/org/ballerinalang/stdlib/time/nativeimpl/ExternMethods.java
@@ -128,21 +128,30 @@ public class ExternMethods {
 
         try {
             ZonedDateTime dateTime = TimeValueHandler.createZoneDateTimeFromCivilValues(year, month, day, hour,
-                    minute, second, zoneHour, zoneMinute, zoneSecond);
+                    minute, second, zoneHour, zoneMinute, zoneSecond, null,
+                    Constants.HeaderZoneHandling.PREFER_ZONE_OFFSET.toString());
             return TimeValueHandler.createUtcFromInstant(dateTime.toInstant());
         } catch (DateTimeException e) {
             return TimeValueHandler.createError(Errors.FormatError, e.getMessage());
         }
     }
 
-    public static BMap<BString, Object> externCivilFromString(BString dateTimeString) {
+    public static Object externCivilFromString(BString dateTimeString) {
 
-        return TimeValueHandler.createCivilFromZoneDateTimeString(dateTimeString.getValue());
+        try {
+            return TimeValueHandler.createCivilFromZoneDateTimeString(dateTimeString.getValue());
+        } catch (DateTimeException e) {
+            return TimeValueHandler.createError(Errors.FormatError, e.getMessage());
+        }
     }
 
-    public static Object externZoneOffsetFromString(BString dateTimeString) {
+    public static Object externCivilFromEmailString(BString dateTimeString) {
 
-        return TimeValueHandler.createZoneOffsetDateTime(dateTimeString.getValue());
+        try {
+            return TimeValueHandler.createCivilFromEmailString(dateTimeString.getValue());
+        } catch (DateTimeException | IllegalArgumentException e) {
+            return TimeValueHandler.createError(Errors.FormatError, e.getMessage());
+        }
     }
 
     public static Object externCivilToString(long year, long month, long day, long hour, long minute, BDecimal second,
@@ -150,7 +159,8 @@ public class ExternMethods {
 
         try {
             ZonedDateTime dateTime = TimeValueHandler.createZoneDateTimeFromCivilValues(year, month, day, hour,
-                    minute, second, zoneHour, zoneMinute, zoneSecond);
+                    minute, second, zoneHour, zoneMinute, zoneSecond, null,
+                    Constants.HeaderZoneHandling.PREFER_ZONE_OFFSET.toString());
             return StringUtils.fromString(dateTime.toInstant().toString());
         } catch (DateTimeException e) {
             return TimeValueHandler.createError(Errors.FormatError, e.getMessage());
@@ -161,7 +171,26 @@ public class ExternMethods {
 
         Instant time = TimeValueHandler.createInstantFromUtc(utc);
         return StringUtils.fromString(ZonedDateTime.ofInstant(time,
-        ZoneId.of(zh.getValue())).format(DateTimeFormatter.RFC_1123_DATE_TIME));
+                ZoneId.of(Constants.GMT_STRING_VALUE)).format(DateTimeFormatter.RFC_1123_DATE_TIME)
+                .replace(Constants.GMT_STRING_VALUE, zh.getValue()));
+    }
+
+    public static Object externCivilToEmailString(long year, long month, long day, long hour, long minute,
+                                                  BDecimal second, long zoneHour, long zoneMinute, BDecimal zoneSecond,
+                                                  BString zoneAbbr, BString zoneHandling) {
+
+        try {
+            ZonedDateTime dateTime = TimeValueHandler.createZoneDateTimeFromCivilValues(year, month, day, hour,
+                    minute, second, zoneHour, zoneMinute, zoneSecond, zoneAbbr, zoneHandling.getValue());
+            if (Constants.HeaderZoneHandling.PREFER_ZONE_OFFSET.toString().equals(zoneHandling.getValue())) {
+                return StringUtils.fromString(dateTime.format(DateTimeFormatter.ofPattern(
+                        Constants.EMAIL_DATE_TIME_FORMAT_WITHOUT_COMMENT)));
+            }
+            return StringUtils.fromString(dateTime.format(DateTimeFormatter.ofPattern(
+                    Constants.EMAIL_DATE_TIME_FORMAT)));
+        } catch (DateTimeException e) {
+            return TimeValueHandler.createError(Errors.FormatError, e.getMessage());
+        }
     }
 
 }

--- a/time-native/src/main/java/org/ballerinalang/stdlib/time/util/Constants.java
+++ b/time-native/src/main/java/org/ballerinalang/stdlib/time/util/Constants.java
@@ -63,6 +63,7 @@ public class Constants {
     public static final String CIVIL_RECORD_UTC_OFFSET = "utcOffset";
     public static final String CIVIL_RECORD_TIME_ABBREV = "timeAbbrev";
     public static final String CIVIL_RECORD_WHICH = "which";
+    public static final String CIVIL_RECORD_DAY_OF_WEEK = "dayOfWeek";
 
     /**
      * Mapping enumeration for Ballerina level HeaderZoneHandling.

--- a/time-native/src/main/java/org/ballerinalang/stdlib/time/util/Constants.java
+++ b/time-native/src/main/java/org/ballerinalang/stdlib/time/util/Constants.java
@@ -28,6 +28,9 @@ import java.math.BigDecimal;
 public class Constants {
     private Constants() {}
     public static final String RECORD_UTC = "Utc";
+    public static final String GMT_STRING_VALUE = "GMT";
+    public static final String EMAIL_DATE_TIME_FORMAT = "EEE, dd MMM yyyy HH:mm:ss Z[ ][(z)]";
+    public static final String EMAIL_DATE_TIME_FORMAT_WITHOUT_COMMENT = "EEE, dd MMM yyyy HH:mm:ss Z";
     public static final int UTC_MAX_PRECISION = 9;
     public static final BigDecimal ANALOG_GIGA = new BigDecimal(1000000000);
     public static final BigDecimal ANALOG_KILO = new BigDecimal(1000);
@@ -61,5 +64,14 @@ public class Constants {
     public static final String CIVIL_RECORD_TIME_ABBREV = "timeAbbrev";
     public static final String CIVIL_RECORD_WHICH = "which";
 
+    /**
+     * Mapping enumeration for Ballerina level HeaderZoneHandling.
+     *
+     */
+    public enum HeaderZoneHandling {
+        PREFER_TIME_ABBREV,
+        PREFER_ZONE_OFFSET,
+        ZONE_OFFSET_WITH_TIME_ABBREV_COMMENT
+    }
 }
 

--- a/time-native/src/main/java/org/ballerinalang/stdlib/time/util/TimeValueHandler.java
+++ b/time-native/src/main/java/org/ballerinalang/stdlib/time/util/TimeValueHandler.java
@@ -108,6 +108,8 @@ public class TimeValueHandler {
                 ValueCreator.createDecimalValue(second));
         civilMap.put(StringUtils.fromString(Constants.CIVIL_RECORD_TIME_ABBREV),
                 StringUtils.fromString(zonedDateTime.getZone().toString()));
+        civilMap.put(StringUtils.fromString(Constants.CIVIL_RECORD_DAY_OF_WEEK),
+                (zonedDateTime.getDayOfWeek().getValue() % 7));
         return civilMap;
     }
 
@@ -133,6 +135,8 @@ public class TimeValueHandler {
             civilMap.put(StringUtils.fromString(Constants.CIVIL_RECORD_UTC_OFFSET),
                     createZoneOffsetFromZonedDateTime(zonedDateTime));
         }
+        civilMap.put(StringUtils.fromString(Constants.CIVIL_RECORD_DAY_OF_WEEK),
+                (zonedDateTime.getDayOfWeek().getValue() % 7));
         return civilMap;
     }
 
@@ -155,6 +159,8 @@ public class TimeValueHandler {
                 StringUtils.fromString(zonedDateTime.getZone().toString()));
         civilMap.put(StringUtils.fromString(Constants.CIVIL_RECORD_UTC_OFFSET),
                 createZoneOffsetFromZonedDateTime(zonedDateTime));
+        civilMap.put(StringUtils.fromString(Constants.CIVIL_RECORD_DAY_OF_WEEK),
+                (zonedDateTime.getDayOfWeek().getValue() % 7));
         return civilMap;
     }
 

--- a/time-native/src/main/java/org/ballerinalang/stdlib/time/util/TimeValueHandler.java
+++ b/time-native/src/main/java/org/ballerinalang/stdlib/time/util/TimeValueHandler.java
@@ -38,6 +38,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
@@ -128,51 +129,106 @@ public class TimeValueHandler {
         }
         civilMap.put(StringUtils.fromString(Constants.CIVIL_RECORD_TIME_ABBREV),
                 StringUtils.fromString(zonedDateTime.getZone().toString()));
+        if (isLocalTimeZoneExists(zonedDateTimeString)) {
+            civilMap.put(StringUtils.fromString(Constants.CIVIL_RECORD_UTC_OFFSET),
+                    createZoneOffsetFromZonedDateTime(zonedDateTime));
+        }
         return civilMap;
     }
 
-    public static Object createZoneOffsetDateTime(String zonedDateTimeStr) {
+    public static BMap<BString, Object> createCivilFromEmailString(String zonedDateTimeString) {
 
-        ZonedDateTime zonedDateTime = ZonedDateTime.parse(zonedDateTimeStr);
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(Constants.EMAIL_DATE_TIME_FORMAT);
+        ZonedDateTime zonedDateTime = ZonedDateTime.parse(zonedDateTimeString, dateTimeFormatter);
+        BigDecimal second = new BigDecimal(zonedDateTime.getSecond());
+        second = second.add(new BigDecimal(zonedDateTime.getNano()).divide(ANALOG_GIGA, MathContext.DECIMAL128));
+        BMap<BString, Object> civilMap = ValueCreator.createRecordValue(ModuleUtils.getModule(),
+                Constants.CIVIL_RECORD);
+        civilMap.put(StringUtils.fromString(Constants.DATE_RECORD_YEAR), zonedDateTime.getYear());
+        civilMap.put(StringUtils.fromString(Constants.DATE_RECORD_MONTH), zonedDateTime.getMonthValue());
+        civilMap.put(StringUtils.fromString(Constants.DATE_RECORD_DAY), zonedDateTime.getDayOfMonth());
+        civilMap.put(StringUtils.fromString(Constants.TIME_OF_DAY_RECORD_HOUR), zonedDateTime.getHour());
+        civilMap.put(StringUtils.fromString(Constants.TIME_OF_DAY_RECORD_MINUTE), zonedDateTime.getMinute());
+        civilMap.put(StringUtils.fromString(Constants.TIME_OF_DAY_RECORD_SECOND),
+                ValueCreator.createDecimalValue(second));
+        civilMap.put(StringUtils.fromString(Constants.CIVIL_RECORD_TIME_ABBREV),
+                StringUtils.fromString(zonedDateTime.getZone().toString()));
+        civilMap.put(StringUtils.fromString(Constants.CIVIL_RECORD_UTC_OFFSET),
+                createZoneOffsetFromZonedDateTime(zonedDateTime));
+        return civilMap;
+    }
+
+    public static BMap<BString, Object> createZoneOffsetFromZonedDateTime(ZonedDateTime zonedDateTime) {
+
         BMap<BString, Object> civilMap = ValueCreator.createRecordValue(ModuleUtils.getModule(),
                 Constants.READABLE_ZONE_OFFSET_RECORD);
-        if (isLocalTimeZoneExists(zonedDateTimeStr)) {
-            Map<String, Integer> zoneInfo = zoneOffsetMapFromString(zonedDateTime.getOffset().toString());
-            if (zoneInfo.get(Constants.ZONE_OFFSET_RECORD_HOUR) != null) {
-                civilMap.put(StringUtils.fromString(Constants.ZONE_OFFSET_RECORD_HOUR),
-                        zoneInfo.get(Constants.ZONE_OFFSET_RECORD_HOUR).longValue());
-            } else {
-                civilMap.put(StringUtils.fromString(Constants.ZONE_OFFSET_RECORD_HOUR), 0);
-            }
-
-            if (zoneInfo.get(Constants.ZONE_OFFSET_RECORD_MINUTE) != null) {
-                civilMap.put(StringUtils.fromString(Constants.ZONE_OFFSET_RECORD_MINUTE),
-                        zoneInfo.get(Constants.ZONE_OFFSET_RECORD_MINUTE).longValue());
-            } else {
-                civilMap.put(StringUtils.fromString(Constants.ZONE_OFFSET_RECORD_MINUTE), 0);
-            }
-
-            if (zoneInfo.get(Constants.ZONE_OFFSET_RECORD_SECOND) != null) {
-                civilMap.put(StringUtils.fromString(Constants.ZONE_OFFSET_RECORD_SECOND),
-                        zoneInfo.get(Constants.ZONE_OFFSET_RECORD_SECOND).longValue());
-            }
-            civilMap.freezeDirect();
-            return civilMap;
+        Map<String, Integer> zoneInfo = zoneOffsetMapFromString(zonedDateTime.getOffset().toString());
+        if (zoneInfo.get(Constants.ZONE_OFFSET_RECORD_HOUR) != null) {
+            civilMap.put(StringUtils.fromString(Constants.ZONE_OFFSET_RECORD_HOUR),
+                    zoneInfo.get(Constants.ZONE_OFFSET_RECORD_HOUR).longValue());
+        } else {
+            civilMap.put(StringUtils.fromString(Constants.ZONE_OFFSET_RECORD_HOUR), 0);
         }
-        return null;
+
+        if (zoneInfo.get(Constants.ZONE_OFFSET_RECORD_MINUTE) != null) {
+            civilMap.put(StringUtils.fromString(Constants.ZONE_OFFSET_RECORD_MINUTE),
+                    zoneInfo.get(Constants.ZONE_OFFSET_RECORD_MINUTE).longValue());
+        } else {
+            civilMap.put(StringUtils.fromString(Constants.ZONE_OFFSET_RECORD_MINUTE), 0);
+        }
+
+        if (zoneInfo.get(Constants.ZONE_OFFSET_RECORD_SECOND) != null) {
+            civilMap.put(StringUtils.fromString(Constants.ZONE_OFFSET_RECORD_SECOND),
+                    zoneInfo.get(Constants.ZONE_OFFSET_RECORD_SECOND).longValue());
+        }
+        civilMap.freezeDirect();
+        return civilMap;
+    }
+
+    public static BMap<BString, Object> createZoneOffsetFromEmailString(ZonedDateTime zonedDateTime) {
+
+        BMap<BString, Object> civilMap = ValueCreator.createRecordValue(ModuleUtils.getModule(),
+                Constants.READABLE_ZONE_OFFSET_RECORD);
+        Map<String, Integer> zoneInfo = zoneOffsetMapFromString(zonedDateTime.getOffset().toString());
+        if (zoneInfo.get(Constants.ZONE_OFFSET_RECORD_HOUR) != null) {
+            civilMap.put(StringUtils.fromString(Constants.ZONE_OFFSET_RECORD_HOUR),
+                    zoneInfo.get(Constants.ZONE_OFFSET_RECORD_HOUR).longValue());
+        } else {
+            civilMap.put(StringUtils.fromString(Constants.ZONE_OFFSET_RECORD_HOUR), 0);
+        }
+
+        if (zoneInfo.get(Constants.ZONE_OFFSET_RECORD_MINUTE) != null) {
+            civilMap.put(StringUtils.fromString(Constants.ZONE_OFFSET_RECORD_MINUTE),
+                    zoneInfo.get(Constants.ZONE_OFFSET_RECORD_MINUTE).longValue());
+        } else {
+            civilMap.put(StringUtils.fromString(Constants.ZONE_OFFSET_RECORD_MINUTE), 0);
+        }
+
+        if (zoneInfo.get(Constants.ZONE_OFFSET_RECORD_SECOND) != null) {
+            civilMap.put(StringUtils.fromString(Constants.ZONE_OFFSET_RECORD_SECOND),
+                    zoneInfo.get(Constants.ZONE_OFFSET_RECORD_SECOND).longValue());
+        }
+        civilMap.freezeDirect();
+        return civilMap;
     }
 
     public static ZonedDateTime createZoneDateTimeFromCivilValues(long year, long month, long day, long hour,
                                                                   long minute, BDecimal second, long zoneHour,
-                                                                  long zoneMinute, BDecimal zoneSecond)
+                                                                  long zoneMinute, BDecimal zoneSecond,
+                                                                  BString zoneAbbr, String zoneHandling)
             throws DateTimeException {
 
+        ZoneId zoneId;
         int intSecond = second.decimalValue().setScale(0, RoundingMode.FLOOR).intValue();
         int intNanoSecond = second.decimalValue().subtract(new BigDecimal(intSecond)).multiply(Constants.ANALOG_GIGA)
                 .setScale(0, RoundingMode.HALF_UP).intValue();
         int intZoneSecond = zoneSecond.decimalValue().setScale(0, RoundingMode.HALF_UP).intValue();
-        ZoneId zoneId = ZoneId.of(ZoneOffset.ofHoursMinutesSeconds(
-                Long.valueOf(zoneHour).intValue(), Long.valueOf(zoneMinute).intValue(), intZoneSecond).toString());
+        if (Constants.HeaderZoneHandling.PREFER_ZONE_OFFSET.toString().equals(zoneHandling)) {
+            zoneId = ZoneId.of(ZoneOffset.ofHoursMinutesSeconds(
+                    Long.valueOf(zoneHour).intValue(), Long.valueOf(zoneMinute).intValue(), intZoneSecond).toString());
+        } else {
+            zoneId = ZoneId.of(zoneAbbr.getValue());
+        }
         return ZonedDateTime.of(
                 Long.valueOf(year).intValue(), Long.valueOf(month).intValue(), Long.valueOf(day).intValue(),
                 Long.valueOf(hour).intValue(), Long.valueOf(minute).intValue(), intSecond, intNanoSecond, zoneId);
@@ -218,7 +274,7 @@ public class TimeValueHandler {
                 zone.put(Constants.ZONE_OFFSET_RECORD_SECOND, Integer.parseInt(zoneInfo[2]));
             }
         } else if (dateTime.strip().startsWith("-")) {
-            dateTime = dateTime.replaceFirst("\\+", "");
+            dateTime = dateTime.replaceFirst("\\-", "");
             String[] zoneInfo = dateTime.split(":");
             if (zoneInfo.length > 0 && zoneInfo[0] != null) {
                 zone.put(Constants.ZONE_OFFSET_RECORD_HOUR, Integer.parseInt(zoneInfo[0]) * -1);
@@ -267,6 +323,7 @@ public class TimeValueHandler {
 
     // Return the ZonedDateTime value that belongs to the `Z` time zone.
     public static ZonedDateTime createZonedDateTimeFromUtc(BArray utc) {
+
         long secondsFromEpoc = 0;
         BigDecimal lastSecondFraction = new BigDecimal(0);
         if (utc.getLength() == 2) {


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1117

## Goal
To support email date-time typed string conversions.

## Approach
Enable APIs for the following use cases:
- convert a given UTC to an email string
- convert a given Civil to an email string
- convert a given email string to Civil

## Release note
Improve the time APIs to support email typed date-time string conversions.

## Automation tests
 - Unit tests 
   > Yes

## Related PRs
https://github.com/ballerina-platform/module-ballerina-time/pull/68

## Test environment
- macOS
- Java 11
- SL Alpha 3

## Learning
- https://stackoverflow.com/questions/2458524/parsing-rfc-2822-date-in-java
- https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html