### PR TITLE
Fix inconsistencies in leading zero of date in utcToEmailString() and civilToEmailString() APIs.

### DIFF
--- a/ballerina/tests/time_test.bal
+++ b/ballerina/tests/time_test.bal
@@ -423,13 +423,13 @@ isolated function testCivilToStringWithInvalidInput() {
 @test:Config {}
 isolated function testUtcToEmailString() returns Error? {
     Utc utc = check utcFromString("2007-12-03T10:15:30.00Z");
-    test:assertEquals(utcToEmailString(utc, "GMT"), "Mon, 03 Dec 2007 10:15:30 GMT");
+    test:assertEquals(utcToEmailString(utc, "GMT"), "Mon, 3 Dec 2007 10:15:30 GMT");
 }
 
 @test:Config {}
 isolated function testUtcToEmailStringWithZ() returns Error? {
     Utc utc = check utcFromString("2007-12-03T10:15:30.00Z");
-    test:assertEquals(utcToEmailString(utc, "Z"), "Mon, 03 Dec 2007 10:15:30 Z");
+    test:assertEquals(utcToEmailString(utc, "Z"), "Mon, 3 Dec 2007 10:15:30 Z");
 }
 
 @test:Config {}
@@ -645,7 +645,7 @@ isolated function testZoneToEmailStringConversion() returns Error? {
     Zone? systemZone = getZone("Asia/Colombo");
     test:assertTrue(systemZone is Zone);
     Civil civil = (<Zone>systemZone).utcToCivil(check utcFromString("2007-12-03T10:15:30.00Z"));
-    test:assertEquals(civilToEmailString(civil, PREFER_TIME_ABBREV), "Mon, 03 Dec 2007 15:45:30 +0530 (IST)");
+    test:assertEquals(civilToEmailString(civil, PREFER_TIME_ABBREV), "Mon, 3 Dec 2007 15:45:30 +0530 (IST)");
 }
 
 @test:Config {}
@@ -669,9 +669,9 @@ isolated function testGmtToEmailStringConversion() returns Error? {
     Utc utc2 = check utcFromString("2007-12-03T10:15:30.00+05:30");
     Civil civil = check civilFromString("2007-12-03T10:15:30.00+00:00");
     
-    test:assertEquals(utcToEmailString(utc, "Z"), "Mon, 03 Dec 2007 10:15:30 Z");
-    test:assertEquals(utcToEmailString(utc2, "0"), "Mon, 03 Dec 2007 04:45:30 +0000");
-    test:assertEquals(utcToEmailString(utc), "Mon, 03 Dec 2007 10:15:30 +0000");
-    test:assertEquals(civilToEmailString(civil, PREFER_TIME_ABBREV), "Mon, 03 Dec 2007 10:15:30 +0000 (Z)");
-    test:assertEquals(civilToEmailString(utcToCivil(utc), PREFER_TIME_ABBREV), "Mon, 03 Dec 2007 10:15:30 +0000 (Z)");
+    test:assertEquals(utcToEmailString(utc, "Z"), "Mon, 3 Dec 2007 10:15:30 Z");
+    test:assertEquals(utcToEmailString(utc2, "0"), "Mon, 3 Dec 2007 04:45:30 +0000");
+    test:assertEquals(utcToEmailString(utc), "Mon, 3 Dec 2007 10:15:30 +0000");
+    test:assertEquals(civilToEmailString(civil, PREFER_TIME_ABBREV), "Mon, 3 Dec 2007 10:15:30 +0000 (Z)");
+    test:assertEquals(civilToEmailString(utcToCivil(utc), PREFER_TIME_ABBREV), "Mon, 3 Dec 2007 10:15:30 +0000 (Z)");
 }

--- a/ballerina/tests/time_test.bal
+++ b/ballerina/tests/time_test.bal
@@ -423,13 +423,13 @@ isolated function testCivilToStringWithInvalidInput() {
 @test:Config {}
 isolated function testUtcToEmailString() returns Error? {
     Utc utc = check utcFromString("2007-12-03T10:15:30.00Z");
-    test:assertEquals(utcToEmailString(utc, "GMT"), "Mon, 3 Dec 2007 10:15:30 GMT");
+    test:assertEquals(utcToEmailString(utc, "GMT"), "Mon, 03 Dec 2007 10:15:30 GMT");
 }
 
 @test:Config {}
 isolated function testUtcToEmailStringWithZ() returns Error? {
     Utc utc = check utcFromString("2007-12-03T10:15:30.00Z");
-    test:assertEquals(utcToEmailString(utc, "Z"), "Mon, 3 Dec 2007 10:15:30 Z");
+    test:assertEquals(utcToEmailString(utc, "Z"), "Mon, 03 Dec 2007 10:15:30 Z");
 }
 
 @test:Config {}
@@ -669,9 +669,9 @@ isolated function testGmtToEmailStringConversion() returns Error? {
     Utc utc2 = check utcFromString("2007-12-03T10:15:30.00+05:30");
     Civil civil = check civilFromString("2007-12-03T10:15:30.00+00:00");
     
-    test:assertEquals(utcToEmailString(utc, "Z"), "Mon, 3 Dec 2007 10:15:30 Z");
-    test:assertEquals(utcToEmailString(utc2, "0"), "Mon, 3 Dec 2007 04:45:30 +0000");
-    test:assertEquals(utcToEmailString(utc), "Mon, 3 Dec 2007 10:15:30 +0000");
+    test:assertEquals(utcToEmailString(utc, "Z"), "Mon, 03 Dec 2007 10:15:30 Z");
+    test:assertEquals(utcToEmailString(utc2, "0"), "Mon, 03 Dec 2007 04:45:30 +0000");
+    test:assertEquals(utcToEmailString(utc), "Mon, 03 Dec 2007 10:15:30 +0000");
     test:assertEquals(civilToEmailString(civil, PREFER_TIME_ABBREV), "Mon, 03 Dec 2007 10:15:30 +0000 (Z)");
     test:assertEquals(civilToEmailString(utcToCivil(utc), PREFER_TIME_ABBREV), "Mon, 03 Dec 2007 10:15:30 +0000 (Z)");
 }

--- a/native/src/main/java/io/ballerina/stdlib/time/nativeimpl/ExternMethods.java
+++ b/native/src/main/java/io/ballerina/stdlib/time/nativeimpl/ExternMethods.java
@@ -29,7 +29,6 @@ import io.ballerina.stdlib.time.util.Errors;
 import io.ballerina.stdlib.time.util.TimeValueHandler;
 import io.ballerina.stdlib.time.util.Utils;
 
-import java.io.PrintStream;
 import java.math.BigDecimal;
 import java.time.DateTimeException;
 import java.time.Instant;
@@ -177,8 +176,7 @@ public class ExternMethods {
             zhString = "+0000";
         }
         return StringUtils.fromString(ZonedDateTime.ofInstant(time,
-                        ZoneId.of(Constants.GMT_STRING_VALUE)).format(DateTimeFormatter.ofPattern(
-                        Constants.EMAIL_DATE_TIME_FORMAT_WITHOUT_COMMENT))
+                        ZoneId.of(Constants.GMT_STRING_VALUE)).format(DateTimeFormatter.RFC_1123_DATE_TIME)
                 .replace(Constants.GMT_STRING_VALUE, zhString).replace(Constants.ZERO_ZONE_STRING_VALUE, zhString));
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/time/nativeimpl/ExternMethods.java
+++ b/native/src/main/java/io/ballerina/stdlib/time/nativeimpl/ExternMethods.java
@@ -29,6 +29,7 @@ import io.ballerina.stdlib.time.util.Errors;
 import io.ballerina.stdlib.time.util.TimeValueHandler;
 import io.ballerina.stdlib.time.util.Utils;
 
+import java.io.PrintStream;
 import java.math.BigDecimal;
 import java.time.DateTimeException;
 import java.time.Instant;
@@ -176,8 +177,9 @@ public class ExternMethods {
             zhString = "+0000";
         }
         return StringUtils.fromString(ZonedDateTime.ofInstant(time,
-                        ZoneId.of(Constants.GMT_STRING_VALUE)).format(DateTimeFormatter.RFC_1123_DATE_TIME)
-                .replace(Constants.GMT_STRING_VALUE, zhString));
+                        ZoneId.of(Constants.GMT_STRING_VALUE)).format(DateTimeFormatter.ofPattern(
+                        Constants.EMAIL_DATE_TIME_FORMAT_WITHOUT_COMMENT))
+                .replace(Constants.GMT_STRING_VALUE, zhString).replace(Constants.ZERO_ZONE_STRING_VALUE, zhString));
     }
 
     public static Object externCivilToEmailString(long year, long month, long day, long hour, long minute,

--- a/native/src/main/java/io/ballerina/stdlib/time/util/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/time/util/Constants.java
@@ -32,6 +32,7 @@ public class Constants {
     private Constants() {}
     public static final String RECORD_UTC = "Utc";
     public static final String GMT_STRING_VALUE = "GMT";
+    public static final String ZERO_ZONE_STRING_VALUE = "+0000";
     public static final String EMAIL_DATE_TIME_FORMAT = "EEE, dd MMM yyyy HH:mm:ss Z[ ][(z)]";
     public static final String EMAIL_DATE_TIME_FORMAT_WITHOUT_COMMENT = "EEE, dd MMM yyyy HH:mm:ss Z";
     public static final int UTC_MAX_PRECISION = 9;

--- a/native/src/main/java/io/ballerina/stdlib/time/util/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/time/util/Constants.java
@@ -33,8 +33,8 @@ public class Constants {
     public static final String RECORD_UTC = "Utc";
     public static final String GMT_STRING_VALUE = "GMT";
     public static final String ZERO_ZONE_STRING_VALUE = "+0000";
-    public static final String EMAIL_DATE_TIME_FORMAT = "EEE, dd MMM yyyy HH:mm:ss Z[ ][(z)]";
-    public static final String EMAIL_DATE_TIME_FORMAT_WITHOUT_COMMENT = "EEE, dd MMM yyyy HH:mm:ss Z";
+    public static final String EMAIL_DATE_TIME_FORMAT = "EEE, d MMM yyyy HH:mm:ss Z[ ][(z)]";
+    public static final String EMAIL_DATE_TIME_FORMAT_WITHOUT_COMMENT = "EEE, d MMM yyyy HH:mm:ss Z";
     public static final int UTC_MAX_PRECISION = 9;
     public static final BigDecimal ANALOG_GIGA = new BigDecimal(1000000000);
     public static final BigDecimal ANALOG_KILO = new BigDecimal(1000);


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/2971 by modifying both APIs to return date without a leading zero.
## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
