### PR TITLE
Add support to convert `time:Civil` to `string` by using the time abbreviation

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "time"
-version = "2.4.0"
+version = "2.4.1"
 authors = ["Ballerina"]
 keywords = ["time", "utc", "epoch", "civil"]
 repository = "https://github.com/ballerina-platform/module-ballerina-time"
@@ -15,5 +15,5 @@ graalvmCompatible = true
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "time-native"
-version = "2.4.0"
-path = "../native/build/libs/time-native-2.4.0.jar"
+version = "2.4.1"
+path = "../native/build/libs/time-native-2.4.1-SNAPSHOT.jar"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "time"
-version = "2.4.1"
+version = "2.5.0"
 authors = ["Ballerina"]
 keywords = ["time", "utc", "epoch", "civil"]
 repository = "https://github.com/ballerina-platform/module-ballerina-time"
@@ -15,5 +15,5 @@ graalvmCompatible = true
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "time-native"
-version = "2.4.1"
-path = "../native/build/libs/time-native-2.4.1-SNAPSHOT.jar"
+version = "2.5.0"
+path = "../native/build/libs/time-native-2.5.0-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -40,7 +40,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "test"}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -40,7 +40,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.4.1"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "test"}

--- a/ballerina/tests/time_test.bal
+++ b/ballerina/tests/time_test.bal
@@ -727,25 +727,6 @@ isolated function testUtcFromCivilWithEmptyTimeOffsetNegative() returns Error? {
     }
 }
 
-@test:Config {enable: false}
-isolated function testCivilToStringWithEmptyTimeOffsetNegative() returns Error? {
-    Civil civil = {
-        year: 2021,
-        month: 4,
-        day: 12,
-        hour: 23,
-        minute: 20,
-        second: 50.52,
-        timeAbbrev: "Asia/Colombo"
-    };
-    string|error civilString = civilToString(civil);
-    if civilString is error {
-        test:assertEquals(civilString.message(), "civil.utcOffset must not be null");
-    } else {
-        test:assertFail("civilString should be error");
-    } 
-}
-
 isolated function testUtcFromCivilWithEmptyTimeOffsetAndAbbreviation() returns Error? {
     Utc expectedUtc = check utcFromString("2021-04-12T23:20:50.520Z");
     Civil civil = {

--- a/ballerina/tests/time_test.bal
+++ b/ballerina/tests/time_test.bal
@@ -387,14 +387,16 @@ isolated function testCivilToStringWithTimeOfDay() returns Error? {
     test:assertEquals(civilStr, expectedStr);
 }
 
-@test:Config {}
+@test:Config {
+    enable: false
+}
 isolated function testCivilToStringWithoutOffset() {
     Civil civil = {
         year: 2021,
         month: 4,
         day: 13,
         hour: 4,
-        minute: 70,
+        minute: 33,
         timeAbbrev: "Asia/Colombo"
     };
     string|Error err = civilToString(civil);
@@ -727,7 +729,7 @@ isolated function testUtcFromCivilWithEmptyTimeOffsetNegative() returns Error? {
     }
 }
 
-@test:Config {enable: true}
+@test:Config {enable: false}
 isolated function testCivilToStringWithEmptyTimeOffsetNegative() returns Error? {
     Civil civil = {
         year: 2021,
@@ -776,7 +778,7 @@ isolated function testCivilToStringWithEmptyTimeOffsetAndAbbreviation() returns 
     };
     string|error civilString = civilToString(civil);
     if civilString is error {
-        test:assertEquals(civilString.message(), "civil.utcOffset must not be null");
+        test:assertEquals(civilString.message(), "civil.utcOffset and civil.timeAbbrev both must not be null");
     } else {
         test:assertFail("civilString should be error");
     } 

--- a/ballerina/tests/time_test.bal
+++ b/ballerina/tests/time_test.bal
@@ -757,7 +757,7 @@ isolated function testCivilToStringWithEmptyTimeOffsetAndAbbreviation() returns 
     };
     string|error civilString = civilToString(civil);
     if civilString is error {
-        test:assertEquals(civilString.message(), "civil.utcOffset and civil.timeAbbrev both must not be null");
+        test:assertEquals(civilString.message(), "the civil value should have either `utcOffset` or `timeAbbrev`");
     } else {
         test:assertFail("civilString should be error");
     } 

--- a/ballerina/tests/time_test.bal
+++ b/ballerina/tests/time_test.bal
@@ -356,7 +356,7 @@ isolated function testCivilToString() returns Error? {
         utcOffset: zoneOffset
     };
     string civilStr = check civilToString(civil);
-    string expectedStr = "2021-03-04T19:03:28.839564Z";
+    string expectedStr = "2021-03-05T00:33:28.839564+05:30";
     test:assertEquals(civilStr, expectedStr);
 }
 
@@ -383,14 +383,12 @@ isolated function testCivilToStringWithTimeOfDay() returns Error? {
         utcOffset: zoneOffset
     };
     string civilStr = check civilToString(civil);
-    string expectedStr = "2021-03-04T19:03:28.839564Z";
+    string expectedStr = "2021-03-05T00:33:28.839564+05:30";
     test:assertEquals(civilStr, expectedStr);
 }
 
-@test:Config {
-    enable: false
-}
-isolated function testCivilToStringWithoutOffset() {
+@test:Config {}
+isolated function testCivilToStringWithTimeAbbreviation() returns Error? {
     Civil civil = {
         year: 2021,
         month: 4,
@@ -399,9 +397,9 @@ isolated function testCivilToStringWithoutOffset() {
         minute: 33,
         timeAbbrev: "Asia/Colombo"
     };
-    string|Error err = civilToString(civil);
-    test:assertTrue(err is Error);
-    test:assertEquals((<Error>err).message(), "civil.utcOffset must not be null");
+    string civilStr = check civilToString(civil);
+    string expectedStr = "2021-04-13T04:33+05:30[Asia/Colombo]";
+    test:assertEquals(civilStr, expectedStr);
 }
 
 @test:Config {}

--- a/ballerina/time_apis.bal
+++ b/ballerina/time_apis.bal
@@ -162,7 +162,7 @@ public isolated function civilFromString(string dateTimeString) returns Civil|Er
     return check externCivilFromString(dateTimeString);
 }
 
-# Obtain a RFC 3339 timestamp (e.g., `2007-12-03T10:15:30.00Z`) from a given `time:Civil`.
+# Obtain a RFC 3339 timestamp (e.g., `2021-03-05T00:33:28.839564+05:30`) from a given `time:Civil`.
 # ```ballerina
 # time:Civil civil = check time:civilFromString("2007-12-03T10:15:30.00Z");
 # string|time:Error civilString = time:civilToString(civil);

--- a/ballerina/time_apis.bal
+++ b/ballerina/time_apis.bal
@@ -176,9 +176,7 @@ public isolated function civilToString(Civil civil) returns string|Error {
     HeaderZoneHandling zoneHandling = PREFER_ZONE_OFFSET;
     if utcOffset is () && timeAbbrev is () {
         return error FormatError("civil.utcOffset and civil.timeAbbrev both must not be null");
-    } else if utcOffset is ZoneOffset {
-        utcOffset = <ZoneOffset>utcOffset;
-    } else if timeAbbrev is string {
+    } else if utcOffset is () && timeAbbrev is string {
         zoneHandling = PREFER_TIME_ABBREV;
     }
 

--- a/ballerina/time_apis.bal
+++ b/ballerina/time_apis.bal
@@ -175,7 +175,7 @@ public isolated function civilToString(Civil civil) returns string|Error {
 
     HeaderZoneHandling zoneHandling = PREFER_ZONE_OFFSET;
     if utcOffset is () && timeAbbrev is () {
-        return error FormatError("civil.utcOffset and civil.timeAbbrev both must not be null");
+        return error FormatError("the civil value should have either `utcOffset` or `timeAbbrev`");
     } else if utcOffset is () && timeAbbrev is string {
         zoneHandling = PREFER_TIME_ABBREV;
     }

--- a/ballerina/time_apis.bal
+++ b/ballerina/time_apis.bal
@@ -170,28 +170,25 @@ public isolated function civilFromString(string dateTimeString) returns Civil|Er
 # + civil - `time:Civil` that needs to be converted
 # + return - The corresponding string value or an error if the specified `time:Civil` contains invalid parameters (e.g., `month` > 12)
 public isolated function civilToString(Civil civil) returns string|Error {
-    ZoneOffset utcOffset = {
-        hours: 0,
-        minutes: 0,
-        seconds: 0
-    };
+    ZoneOffset? utcOffset = civil?.utcOffset;
+    string? timeAbbrev = civil?.timeAbbrev;
+
     HeaderZoneHandling zoneHandling = PREFER_ZONE_OFFSET;
-    if civil?.utcOffset is () && civil?.timeAbbrev is () {
+    if utcOffset is () && timeAbbrev is () {
         return error FormatError("civil.utcOffset and civil.timeAbbrev both must not be null");
     } else if civil?.utcOffset is ZoneOffset {
         utcOffset = <ZoneOffset>civil?.utcOffset;
-    } else if civil?.timeAbbrev is string {
+    } else if timeAbbrev is string {
         zoneHandling = PREFER_TIME_ABBREV;
     }
 
-    string timeAbbrev = civil?.timeAbbrev ?: "";
-    decimal? civilTimeSecField = civil?.second;
-    decimal? utcOffsetSecField = utcOffset?.seconds;
-    decimal civilTimeSeconds = (civilTimeSecField is Seconds) ? civilTimeSecField : 0.0;
-    decimal utcOffsetSeconds = (utcOffsetSecField is decimal) ? utcOffsetSecField : 0.0;
+    int utcOffsetHours = utcOffset?.hours ?: 0;
+    int utcOffsetMinutes = utcOffset?.minutes ?: 0;
+    decimal utcOffsetSeconds = utcOffset?.seconds ?: 0.0;
+    decimal civilTimeSeconds = civil?.second ?: 0.0;
 
-    return externCivilToString(civil.year, civil.month, civil.day, civil.hour, civil.minute, civilTimeSeconds, utcOffset.
-    hours, utcOffset.minutes, utcOffsetSeconds, timeAbbrev, zoneHandling);
+    return externCivilToString(civil.year, civil.month, civil.day, civil.hour, civil.minute, civilTimeSeconds, 
+        utcOffsetHours, utcOffsetMinutes, utcOffsetSeconds, timeAbbrev ?: "", zoneHandling);
 }
 
 # Converts a given UTC to an email formatted string (e.g `Mon, 3 Dec 2007 10:15:30 GMT`).

--- a/ballerina/time_apis.bal
+++ b/ballerina/time_apis.bal
@@ -176,8 +176,8 @@ public isolated function civilToString(Civil civil) returns string|Error {
     HeaderZoneHandling zoneHandling = PREFER_ZONE_OFFSET;
     if utcOffset is () && timeAbbrev is () {
         return error FormatError("civil.utcOffset and civil.timeAbbrev both must not be null");
-    } else if civil?.utcOffset is ZoneOffset {
-        utcOffset = <ZoneOffset>civil?.utcOffset;
+    } else if utcOffset is ZoneOffset {
+        utcOffset = <ZoneOffset>utcOffset;
     } else if timeAbbrev is string {
         zoneHandling = PREFER_TIME_ABBREV;
     }

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+
+### Fixed
+- [When converting a `time:Civil` with time-zone information to a string using `time:civilToString` API error is thrown](https://github.com/ballerina-platform/ballerina-library/issues/6986)
+
+## [2.3.0] - 2023-06-30
 ### changed
 - [Mark Standard Libraries as GraalVM Compatible](https://github.com/ballerina-platform/ballerina-standard-library/issues/4568)
 - [Add support for inferring utc offset for zulu time(Z) in utcFromCivil and civilToString APIs](https://github.com/ballerina-platform/module-ballerina-time/pull/459) 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -115,7 +115,7 @@ The time library contains several conversion APIs to convert UTC to civil. The t
     ```ballerina
     public isolated function civilFromString(string dateTimeString) returns Civil|Error;
     ```
-4. Civil to an RFC timestamp string
+4. Civil to an RFC 3339 timestamp string (e.g., `2021-03-05T00:33:28.839564+05:30`).
     ```ballerina
     public isolated function civilToString(Civil civil) returns string|Error;
     ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=2.4.1-SNAPSHOT
+version=2.5.0-SNAPSHOT
 ballerinaLangVersion=2201.8.0
 puppycrawlCheckstyleVersion=10.12.0
 ballerinaGradlePluginVersion=2.0.1

--- a/native/src/main/java/io/ballerina/stdlib/time/nativeimpl/ExternMethods.java
+++ b/native/src/main/java/io/ballerina/stdlib/time/nativeimpl/ExternMethods.java
@@ -157,12 +157,12 @@ public class ExternMethods {
     }
 
     public static Object externCivilToString(long year, long month, long day, long hour, long minute, BDecimal second,
-                                             long zoneHour, long zoneMinute, BDecimal zoneSecond) {
+                                             long zoneHour, long zoneMinute, BDecimal zoneSecond, BString zoneAbbr,
+                                             BString zoneHandling) {
 
         try {
             ZonedDateTime dateTime = TimeValueHandler.createZoneDateTimeFromCivilValues(year, month, day, hour,
-                    minute, second, zoneHour, zoneMinute, zoneSecond, null,
-                    Constants.HeaderZoneHandling.PREFER_ZONE_OFFSET.toString());
+                    minute, second, zoneHour, zoneMinute, zoneSecond, zoneAbbr, zoneHandling.getValue());
             return StringUtils.fromString(dateTime.toInstant().toString());
         } catch (DateTimeException e) {
             return Utils.createError(Errors.FormatError, e.getMessage());

--- a/native/src/main/java/io/ballerina/stdlib/time/nativeimpl/ExternMethods.java
+++ b/native/src/main/java/io/ballerina/stdlib/time/nativeimpl/ExternMethods.java
@@ -163,7 +163,7 @@ public class ExternMethods {
         try {
             ZonedDateTime dateTime = TimeValueHandler.createZoneDateTimeFromCivilValues(year, month, day, hour,
                     minute, second, zoneHour, zoneMinute, zoneSecond, zoneAbbr, zoneHandling.getValue());
-            return StringUtils.fromString(dateTime.toInstant().toString());
+            return StringUtils.fromString(dateTime.toString());
         } catch (DateTimeException e) {
             return Utils.createError(Errors.FormatError, e.getMessage());
         }


### PR DESCRIPTION
## Purpose
> $subject

Fixes: [#6986](https://github.com/ballerina-platform/ballerina-library/issues/6986)
Related to: [#778](https://github.com/wso2-enterprise/internal-support-ballerina/issues/778)

## Examples
```ballerina
time:Utc utc = time:utcNow();
time:TimeZone zone = check new ("America/New_York");
time:Civil civilTime = zone.utcToCivil(utc);
string civilDate = check time:civilToString(civilTime);
io:println(civilDate);
```

Result:
```sh
2024-09-12T07:29:45.674107370-04:00[America/New_York]
```

## Checklist
- [X] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
- [ ] Checked native-image compatibility
