### PR TITLE
Fix issues with Dead Code Elimination feature

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,13 +1,13 @@
 [package]
 org = "ballerina"
 name = "time"
-version = "2.5.0"
+version = "2.6.0"
 authors = ["Ballerina"]
 keywords = ["time", "utc", "epoch", "civil"]
 repository = "https://github.com/ballerina-platform/module-ballerina-time"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.8.0"
+distribution = "2201.11.0"
 
 [platform.java17]
 graalvmCompatible = true
@@ -15,5 +15,5 @@ graalvmCompatible = true
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "time-native"
-version = "2.5.0"
-path = "../native/build/libs/time-native-2.5.0.jar"
+version = "2.6.0"
+path = "../native/build/libs/time-native-2.6.0-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.8.0"
+distribution-version = "2201.11.0-20241101-105200-f94714be"
 
 [[package]]
 org = "ballerina"
@@ -13,6 +13,26 @@ name = "jballerina.java"
 version = "0.0.0"
 modules = [
 	{org = "ballerina", packageName = "jballerina.java", moduleName = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.__internal"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.object"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.array"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.__internal"}
 ]
 
 [[package]]
@@ -26,11 +46,18 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.object"
+version = "0.0.0"
+scope = "testOnly"
+
+[[package]]
+org = "ballerina"
 name = "test"
 version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.array"},
 	{org = "ballerina", name = "lang.error"}
 ]
 modules = [
@@ -40,7 +67,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "test"}

--- a/ballerina/time_types.bal
+++ b/ballerina/time_types.bal
@@ -135,6 +135,7 @@ public type ZoneOffset readonly & record {|
     decimal seconds?;
 |};
 
+@java:ExternalDependency
 type ReadWriteZoneOffset record {|
     int hours;
     int minutes = 0;

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["time", "utc", "epoch", "civil"]
 repository = "https://github.com/ballerina-platform/module-ballerina-time"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.8.0"
+distribution = "2201.11.0"
 
 [platform.java17]
 graalvmCompatible = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=2.5.1-SNAPSHOT
-ballerinaLangVersion=2201.8.0
+version=2.6.0-SNAPSHOT
+ballerinaLangVersion=2201.11.0-20241101-105200-f94714be
 puppycrawlCheckstyleVersion=10.12.0
 ballerinaGradlePluginVersion=2.0.1


### PR DESCRIPTION
## Purpose

> $Subject

Part of: https://github.com/ballerina-platform/ballerina-library/issues/7339

Obtained following error when running the tests with DCE feature:
```console
error("No such record: ReadWriteZoneOffset")
```

This `ReadWriteZoneOffset` is a private record is used with the `ValueCreator.createRecordValue` API, to create a modifiable record value for the `ZoneOffset` record(this type is readonly).

There are few other usages of [`ValueCreator`](https://github.com/search?q=repo%3Aballerina-platform%2Fmodule-ballerina-time%20%22ValueCreator.%22&type=code) and [`TypeCreator`](https://github.com/search?q=repo%3Aballerina-platform%2Fmodule-ballerina-time%20%22TypeCreator.%22&type=code). But since the referred types are already exposed in the external function call return type, they will be included by default.

## Examples

N/A

## Checklist
- [x] Linked to an issue
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
- [ ] ~Updated the spec~
- [x] Checked native-image compatibility
