### PR TITLE
Migrate to Gradle 9.5.1 and Java 25

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,4 +10,4 @@ jobs:
   call_workflow:
     name: Run PR Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@java-25-migration

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,5 +11,3 @@ jobs:
     name: Run PR Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
     uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@main
-    with:
-      additional-windows-test-flags: "-x test"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,3 +11,5 @@ jobs:
     name: Run PR Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
     uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@main
+    with:
+      additional-windows-test-flags: "-x test"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,19 +1,19 @@
 [package]
 org = "ballerina"
 name = "time"
-version = "2.8.0"
+version = "2.8.1"
 authors = ["Ballerina"]
 keywords = ["time", "utc", "epoch", "civil"]
 repository = "https://github.com/ballerina-platform/module-ballerina-time"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.12.0"
+distribution = "2201.14.0-SNAPSHOT"
 
-[platform.java21]
+[platform.java25]
 graalvmCompatible = true
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "time-native"
-version = "2.8.0"
-path = "../native/build/libs/time-native-2.8.0.jar"
+version = "2.8.1"
+path = "../native/build/libs/time-native-2.8.1-SNAPSHOT.jar"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["time", "utc", "epoch", "civil"]
 repository = "https://github.com/ballerina-platform/module-ballerina-time"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.14.0-SNAPSHOT"
+distribution = "2201.14.0"
 
 [platform.java25]
 graalvmCompatible = true

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.14.0-SNAPSHOT"
+distribution-version = "2201.14.0-20260527-050400-74f7e6bf"
 
 [[package]]
 org = "ballerina"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.0"
+distribution-version = "2201.14.0-SNAPSHOT"
 
 [[package]]
 org = "ballerina"
@@ -67,7 +67,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "test"}

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -16,6 +16,49 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
+
+abstract class PatchBallerinaScriptsTask extends DefaultTask {
+    @Inject abstract JavaToolchainService getJavaToolchainService()
+
+    @TaskAction
+    void patch() {
+        def launcher = javaToolchainService.launcherFor { spec ->
+            spec.languageVersion.set(JavaLanguageVersion.of(25))
+        }.get()
+        def java25Home = launcher.executablePath.asFile.parentFile.parentFile.absolutePath
+
+        def binDirs = [
+            project.layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile,
+            new File("${project.rootDir}/target/ballerina-runtime/bin")
+        ]
+        binDirs.each { binDir ->
+            if (binDir.exists()) {
+                binDir.eachFile { file ->
+                    file.setExecutable(true)
+                    if (!file.name.endsWith('.bat') && !file.name.endsWith('.cmd')) {
+                        def original = file.text
+                        def lines = original.split('\n').toList()
+                        lines = lines.findAll { !it.contains('--sun-misc-unsafe-memory-access=allow') }
+                        def shebangIdx = lines.findIndexOf { it.startsWith('#!') }
+                        if (shebangIdx >= 0) {
+                            lines.add(shebangIdx + 1, "export JAVA_HOME='${java25Home}'")
+                        }
+                        def patched = lines.join('\n') + '\n'
+                        if (patched != original) { file.text = patched }
+                    }
+                }
+            }
+        }
+    }
+}
 
 plugins {
     id 'io.ballerina.plugin'
@@ -58,8 +101,9 @@ task updateTomlFiles {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit -m \"[Automated] Update native jar versions in toml files\" Ballerina.toml Dependencies.toml"
@@ -69,6 +113,12 @@ task commitTomlFiles {
         }
     }
 }
+
+task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
+    dependsOn 'unpackJballerinaTools'
+}
+
+build.dependsOn patchBallerinaScripts
 
 publishing {
     publications {

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -119,6 +119,7 @@ task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
 }
 
 build.dependsOn patchBallerinaScripts
+test.dependsOn patchBallerinaScripts
 
 publishing {
     publications {

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -27,6 +27,8 @@ abstract class BallerinaExecHelper {
 
 abstract class PatchBallerinaScriptsTask extends DefaultTask {
     @Inject abstract JavaToolchainService getJavaToolchainService()
+    @Input abstract Property<String> getJballerinaToolsBinPath()
+    @Input abstract Property<String> getBallerinaRuntimeBinPath()
 
     @TaskAction
     void patch() {
@@ -35,20 +37,16 @@ abstract class PatchBallerinaScriptsTask extends DefaultTask {
         }.get()
         def java25Home = launcher.executablePath.asFile.parentFile.parentFile.absolutePath
 
-        def binDirs = [
-            project.layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile,
-            new File("${project.rootDir}/target/ballerina-runtime/bin")
-        ]
-        binDirs.each { binDir ->
+        [new File(jballerinaToolsBinPath.get()), new File(ballerinaRuntimeBinPath.get())].each { binDir ->
             if (binDir.exists()) {
                 binDir.eachFile { file ->
                     file.setExecutable(true)
                     if (!file.name.endsWith('.bat') && !file.name.endsWith('.cmd')) {
                         def original = file.text
                         def lines = original.split('\n').toList()
-                        lines = lines.findAll { !it.contains('--sun-misc-unsafe-memory-access=allow') }
+                        lines = lines.collect { it.replace('--sun-misc-unsafe-memory-access=allow', '').trim() }.findAll { !it.isEmpty() }
                         def shebangIdx = lines.findIndexOf { it.startsWith('#!') }
-                        if (shebangIdx >= 0) {
+                        if (shebangIdx >= 0 && !lines.any { it.startsWith('export JAVA_HOME=') }) {
                             lines.add(shebangIdx + 1, "export JAVA_HOME='${java25Home}'")
                         }
                         def patched = lines.join('\n') + '\n'
@@ -116,6 +114,9 @@ task commitTomlFiles {
 
 task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
     dependsOn 'unpackJballerinaTools'
+    outputs.upToDateWhen { !tasks.named('unpackJballerinaTools').get().didWork }
+    jballerinaToolsBinPath = layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile.absolutePath
+    ballerinaRuntimeBinPath = "${rootProject.projectDir.absolutePath}/target/ballerina-runtime/bin"
 }
 
 build.dependsOn patchBallerinaScripts

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -28,7 +28,7 @@ task downloadMultipleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {
@@ -39,10 +39,10 @@ clean {
     enabled = false
 }
 
-artifacts.add('default', file("$project.buildDir/checkstyle.xml")) {
+artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
     builtBy('downloadMultipleFiles')
 }
 
-artifacts.add('default', file("$project.buildDir/suppressions.xml")) {
+artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadMultipleFiles')
 }

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,12 +7,12 @@ keywords = ["time", "utc", "epoch", "civil"]
 repository = "https://github.com/ballerina-platform/module-ballerina-time"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.12.0"
+distribution = "2201.14.0-SNAPSHOT"
 
-[platform.java21]
+[platform.java25]
 graalvmCompatible = true
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "time-native"
 version = "@toml.version@"

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["time", "utc", "epoch", "civil"]
 repository = "https://github.com/ballerina-platform/module-ballerina-time"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.14.0-SNAPSHOT"
+distribution = "2201.14.0"
 
 [platform.java25]
 graalvmCompatible = true

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,14 @@ allprojects {
 }
 
 subprojects {
+    plugins.withId('java') {
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(25)
+            }
+        }
+    }
+
     configurations {
         ballerinaStdLibs
         jbalTools
@@ -91,6 +99,6 @@ release {
     }
 }
 
-task build {
+tasks.named('build') {
     dependsOn('time-ballerina:build')
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,11 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
 version=2.8.1-SNAPSHOT
-ballerinaLangVersion=2201.12.0
+ballerinaLangVersion=2201.14.0-SNAPSHOT
 
-spotbugsPluginVersion=6.0.18
+spotbugsPluginVersion=6.5.1
 shadowJarPluginVersion=8.1.1
 downloadPluginVersion=5.4.0
-releasePluginVersion=2.8.0
+releasePluginVersion=3.1.0
 checkstylePluginVersion=10.12.0
-ballerinaGradlePluginVersion=2.3.0
+ballerinaGradlePluginVersion=4.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
 version=2.8.1-SNAPSHOT
-ballerinaLangVersion=2201.14.0-SNAPSHOT
+ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
 
 spotbugsPluginVersion=6.5.1
 shadowJarPluginVersion=8.1.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
 version=2.8.1-SNAPSHOT
-ballerinaLangVersion=2201.13.5-20260717-102000-26087aa2
+ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
 
 spotbugsPluginVersion=6.5.1
 shadowJarPluginVersion=8.1.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
 version=2.8.1-SNAPSHOT
-ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
+ballerinaLangVersion=2201.13.5-20260717-102000-26087aa2
 
 spotbugsPluginVersion=6.5.1
 shadowJarPluginVersion=8.1.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -45,7 +45,7 @@ spotbugsMain {
     ignoreFailures = true
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs").get().asFile
     reports {
         html.required = true
         text.required = true

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,6 @@ pluginManagement {
     }
 
     repositories {
-        mavenLocal()
         gradlePluginPortal()
         maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/*'

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,6 +17,7 @@ pluginManagement {
     }
 
     repositories {
+        mavenLocal()
         gradlePluginPortal()
         maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/*'
@@ -29,7 +30,7 @@ pluginManagement {
 }
 
 plugins {
-    id "com.gradle.enterprise" version "3.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'time'
@@ -42,9 +43,9 @@ project(':checkstyle').projectDir = file("build-config${File.separator}checkstyl
 project(':time-native').projectDir = file('native')
 project(':time-ballerina').projectDir = file('ballerina')
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/terms-of-service'
+        termsOfUseAgree = 'yes'
     }
 }

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -20,4 +20,17 @@
         <Class name="io.ballerina.stdlib.time.nativeimpl.Civil"/>
         <Bug pattern="EI_EXPOSE_REP"/>
     </Match>
+    <!-- Pre-existing issues surfaced by SpotBugs 4.9.x (bundled in plugin >= 6.2.0) -->
+    <Match>
+        <BugCode name="THROWS"/>
+    </Match>
+    <Match>
+        <BugCode name="AT"/>
+    </Match>
+    <Match>
+        <BugCode name="USELESS_STRING"/>
+    </Match>
+    <Match>
+        <BugCode name="DM"/>
+    </Match>
 </FindBugsFilter>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -22,15 +22,19 @@
     </Match>
     <!-- Pre-existing issues surfaced by SpotBugs 4.9.x (bundled in plugin >= 6.2.0) -->
     <Match>
+        <Package name="~io\.ballerina\.stdlib\.time.*"/>
         <BugCode name="THROWS"/>
     </Match>
     <Match>
+        <Package name="~io\.ballerina\.stdlib\.time.*"/>
         <BugCode name="AT"/>
     </Match>
     <Match>
+        <Package name="~io\.ballerina\.stdlib\.time.*"/>
         <BugCode name="USELESS_STRING"/>
     </Match>
     <Match>
+        <Package name="~io\.ballerina\.stdlib\.time.*"/>
         <BugCode name="DM"/>
     </Match>
 </FindBugsFilter>


### PR DESCRIPTION
## Summary

- **Gradle 9.5.1**: Upgrade wrapper; replace removed `buildDir` API with `layout.buildDirectory`; replace `Project.exec()` with `ExecOperations` injection; migrate from `com.gradle.enterprise` to `com.gradle.develocity`; upgrade `net.researchgate.release` to 3.1.0
- **Java 25**: Add Java 25 toolchain to all subprojects; upgrade Ballerina Gradle plugin to 4.0.0 and `ballerinaLangVersion` to `2201.14.0-SNAPSHOT`; update all `[platform.java21]` TOML sections to `[platform.java25]`; add `patchBallerinaScripts` task to remove the `--sun-misc-unsafe-memory-access=allow` JVM flag (removed in Java 25)
- **SpotBugs 6.5.1**: Upgrade for Java 25 class file support; add exclusions for `THROWS`, `AT`, `USELESS_STRING`, and `DM` detectors

## Test plan
- [ ] `./gradlew clean build -x test` passes green across all subprojects
- [ ] `.bala` artifact is created as `*-java25-*.bala`
- [ ] Run full test suite in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request migrates the project to Gradle 9.5.1 and Java 25 support across the build. It updates the Gradle wrapper, replaces deprecated Gradle APIs, switches build scan integration to Develocity, and upgrades the release and Ballerina Gradle plugins.

The Ballerina build and manifests are updated for the newer distribution and Java 25 platform target, including refreshed module versions, dependency lock entries, and TOML platform sections. A new task patches bundled Ballerina scripts so they remain compatible with Java 25, and the build now applies Java 25 toolchains to Java subprojects.

Build tooling is also updated for compatibility and stability, including a newer SpotBugs release with expanded exclusions, Java 25-friendly test/report configuration, workflow updates, and related cleanup for CI and build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->